### PR TITLE
feat(expect): added null as positive value for toBeOptionalOf

### DIFF
--- a/packages/expect-more-jest/src/to-be-optional-of.ts
+++ b/packages/expect-more-jest/src/to-be-optional-of.ts
@@ -1,4 +1,4 @@
-import { isUndefined } from 'expect-more';
+import { isUndefined, isNull } from 'expect-more';
 import { equals } from 'expect/build/jasmineUtils';
 import { printExpected, printReceived } from 'jest-matcher-utils';
 import { createResult } from './lib/create-result';
@@ -7,7 +7,7 @@ declare global {
   namespace jest {
     interface Matchers<R> {
       /**
-       * Asserts that a value is equal to ${other} or undefined.
+       * Asserts that a value is equal to ${other} or undefined or null.
        * @example
        * expect({ x: 12, y: 22 }).toBeOptionalOf({
        *   x: expect.toBeNumber(),
@@ -17,12 +17,16 @@ declare global {
        *   x: expect.toBeNumber(),
        *   y: expect.toBeNumber(),
        * });
+       * expect(null).toBeOptionalOf({
+       *   x: expect.toBeNumber(),
+       *   y: expect.toBeNumber(),
+       * });
        */
       toBeOptionalOf(other: unknown): R;
     }
     interface Expect {
       /**
-       * Asserts that a value is equal to ${other} or undefined.
+       * Asserts that a value is equal to ${other} or undefined or null.
        * @example
        * expect({ x: 12, y: 22 }).toEqual(
        *   expect.toBeOptionalOf({
@@ -36,6 +40,10 @@ declare global {
        *     y: expect.toBeNumber()
        *   })
        * );
+       * expect(null).toBeOptionalOf({
+       *   x: expect.toBeNumber(),
+       *   y: expect.toBeNumber(),
+       * });
        */
       toBeOptionalOf<T>(other: unknown): JestMatchers<T>;
     }
@@ -47,12 +55,12 @@ export const toBeOptionalOfMatcher = (value: unknown, other: unknown): jest.Cust
     message: () =>
       `expected ${printReceived(value)} to equal ${printExpected(other)} or ${printExpected(
         undefined,
-      )}`,
+      )} or ${printExpected(null)}`,
     notMessage: () =>
       `expected ${printReceived(value)} not to equal ${printExpected(other)} or ${printExpected(
         undefined,
-      )}`,
-    pass: isUndefined(value) || equals(value, other),
+      )} or ${printExpected(null)}`,
+    pass: isUndefined(value) || isNull(value) || equals(value, other),
   });
 
 expect.extend({ toBeOptionalOf: toBeOptionalOfMatcher });

--- a/packages/expect-more-jest/test/to-be-optional-of.spec.ts
+++ b/packages/expect-more-jest/test/to-be-optional-of.spec.ts
@@ -8,6 +8,7 @@ const expectedShape = {
 it('provides expect().toBeOptionalOf()', () => {
   expect({ x: 0, y: 12 }).toBeOptionalOf(expectedShape);
   expect(undefined).toBeOptionalOf(expectedShape);
+  expect(null).toBeOptionalOf(expectedShape);
 });
 
 it('provides expect().not.toBeOptionalOf()', () => {


### PR DESCRIPTION
## Description (What)
It would be nice to have `null` as a positive value(as well as `undefined`) for `toBeOptionalOf`
<!--
Add context so reviewers understand what it is they're looking at. Describe what
this change does and what was required to deliver it. This section also helps
those who might need to modify your code at a time when you're not available,
and need help understanding it in order to get started.
-->

## Justification (Why)
There are cases when object received from server (dto) has null as a value. In this case `toBeOptionalOf` fails which not correct. It should treat `null` the same way as `undefined`
<!--
Describe why this change is required, what problem it solves, and what
alternatives exist that you might have considered. This helps reviewers
understand the value of this change, or to highlight unnecessary changes which
can be avoided.
-->

## How Can This Be Tested?

<!--
Bullet-list how reviewers can install, build, test, and run your changes.
-->
